### PR TITLE
Add container registry to allowed values

### DIFF
--- a/templates/manager.yaml
+++ b/templates/manager.yaml
@@ -21,7 +21,7 @@ spec:
       {{- end }}
       containers:
         - name: main
-          image: schemahero/schemahero-manager:{{ .Chart.AppVersion }}
+          image: {{ .Values.registry }}schemahero/schemahero-manager:{{ .Chart.AppVersion }}
           imagePullPolicy: IfNotPresent
           command:
             - /manager

--- a/values.schema.json
+++ b/values.schema.json
@@ -35,6 +35,10 @@
         "name": { "type": "string"},
         "value": {"type": "string"}
       }
+    },
+    "registry": {
+      "type": "string",
+      "description": "Alternate container registry"
     }
   },
 

--- a/values.yaml
+++ b/values.yaml
@@ -1,6 +1,9 @@
 service:
   port: 443
 
+# Defaults to Docker Hub
+registry: ""
+
 extraArgs: []
 
 # name-value pairs, see https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/


### PR DESCRIPTION
Hello! We would love to use this but we use an internal registry (in our case AWS ECR) for our clusters. Would you be willing to somehow expose the ability to set this, leaving the default as Docker Hub as it is today?

I am not a helm expert so I am willing to do this a different way if desired. Thank you!