### PR TITLE
feat: allow use of custom image name

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -15,7 +15,7 @@ deploy:
         chartPath: .
         wait: true
         artifactOverrides:
-          image: schemahero/schemahero-e2e
+          tests_image: schemahero/schemahero-e2e
         imageStrategy:
           helm: {}
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -5,7 +5,8 @@
 {{- define "schemahero.labels" -}}
 helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version }}
 {{ include "schemahero.selectorLabels" . }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{/* If image is passed with @sha256 part, we don't want it in labels */}}
+app.kubernetes.io/version: {{ index (regexSplit "@sha256:" (.Values.image.tag | default .Chart.AppVersion) -1) 0 | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 

--- a/templates/manager.yaml
+++ b/templates/manager.yaml
@@ -21,7 +21,7 @@ spec:
       {{- end }}
       containers:
         - name: main
-          image: {{ .Values.registry }}schemahero/schemahero-manager:{{ .Chart.AppVersion }}
+          image: {{ .Values.image.registry }}{{ .Values.image.name }}:{{ .Values.image.tag | default .Chart.AppVersion }}
           imagePullPolicy: IfNotPresent
           command:
             - /manager

--- a/templates/tests/testdb.yaml
+++ b/templates/tests/testdb.yaml
@@ -1,5 +1,6 @@
-
-{{- $dict := .Values.image | default (dict "tag" .Chart.Version "repository" "schemahero-testdb") -}}
+---
+{{/* These tags are overrided during tests */}}
+{{- $dict := .Values.tests_image | default (dict "tag" .ChartVersion "repository" "schemahero-testdb") -}}
 {{- $image := printf "%s:%s" $dict.repository $dict.tag -}}
 apiVersion: v1
 kind: Pod

--- a/values.schema.json
+++ b/values.schema.json
@@ -36,9 +36,26 @@
         "value": {"type": "string"}
       }
     },
-    "registry": {
-      "type": "string",
-      "description": "Alternate container registry"
+    "image": {
+      "type": "object",
+      "title": "Schemahero manager image settings",
+      "additionalProperties": false,
+      "required": [],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Schemahero manager image name",
+          "default": "schemahero/schemahero-manager"
+        },
+        "tag": {
+          "type": "string",
+          "description": "Schemahero manager image tag, substituted with `.Chart.AppVersion` if unspecified"
+        },
+        "registry": {
+          "type": "string",
+          "description": "Alternate container registry"
+        }
+      }
     }
   },
 

--- a/values.yaml
+++ b/values.yaml
@@ -1,8 +1,12 @@
 service:
   port: 443
 
-# Defaults to Docker Hub
-registry: ""
+image:
+  name: schemahero/schemahero-manager
+  # Will use .Chart.AppVersion by default
+  tag: ""
+  # Defaults to Docker Hub
+  registry: ""
 
 extraArgs: []
 


### PR DESCRIPTION
This also implements #8.
I've made backward incompatible change in values with #4 as I've moved previous `.registry` property under `.image` to keep all image-related settings grouped.