### PR TITLE
feat: Fixes StatefulSet

### DIFF
--- a/templates/manager.yaml
+++ b/templates/manager.yaml
@@ -28,7 +28,7 @@ spec:
             - run
             - --enable-database-controller
             {{- range .Values.extraArgs }}
-            {{ . }}
+            - {{ . }}
             {{- end }}
           ports:
             - name: webhook


### PR DESCRIPTION
Fixes `StatefulSet` so that the arguments (explicitly defined on `extraArgs` - `values.yaml`) can be correctly passed to `manager` by specifying the log level, etc.