### PR TITLE
ci: upgrade setup-helm, npm-install

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,9 +11,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: azure/setup-helm@v1
-        with:
-          version: '3.7.0'
+      - uses: azure/setup-helm@v4.3.1
       - uses: bahmutov/npm-install@v1.10.10
       - run: npx semantic-release
         env:


### PR DESCRIPTION
- Replace azure/setup-helm@v1 with @v4 to stop using deprecated set-output